### PR TITLE
Enable boot without watchdog

### DIFF
--- a/main.c
+++ b/main.c
@@ -50,6 +50,11 @@ static EFI_STATUS scan_devices(EFI_LOADED_IMAGE *loaded_image, UINTN timeout)
 	EFI_STATUS status;
 	UINT32 value;
 
+    if (timeout == 0) {
+        Print(L"Watchdog is disabled.\n");
+        return EFI_SUCCESS;
+    }
+
 	status = uefi_call_wrapper(BS->LocateHandle, 5, ByProtocol,
 				   &PciIoProtocol, NULL, &size, devices);
 	if (EFI_ERROR(status)) {


### PR DESCRIPTION
This patch allows booting an image without arming watchdog timer
whwn "watchdog=0" parameter is passed to the to the module.

This covers the use case when availability of a hardware driver is
unknown ahead of time and can only be established upon first boot.
The code that runs on the first boot can then identify if supported
hardware watchdog is available and the required driver is present
in the kernel and either update boot configuration re-arming the
timer or issuing a warning unsupported hardware. This also allows
for booting images in virtual environments.