### PR TITLE
configure: bootloader optional

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -135,6 +135,7 @@ install-exec-hook:
 #
 efi_loadername = efibootguard$(MACHINE_TYPE_NAME).efi
 
+if BOOTLOADER
 if ARCH_AARCH64
 efi_sources_watchdogs =
 else
@@ -249,6 +250,7 @@ $(efi_loadername): $(efi_solib)
 	$(AM_V_GEN) $(OBJCOPY) -j .text -j .sdata -j .data -j .dynamic \
 	  -j .dynsym -j .rel -j .rela -j .reloc -j .init_array \
 	  -j .rela.got -j .rela.data $(objcopy_format) $< $@
+endif
 
 $(top_builddir)/tools/bg_setenv-bg_setenv.o: $(GEN_VERSION_H)
 

--- a/configure.ac
+++ b/configure.ac
@@ -179,7 +179,16 @@ if test "x$PKG_CONFIG" = "xno"; then
 	AC_MSG_ERROR([You need to install pkg-config])
 fi
 PKG_CHECK_MODULES(LIBCHECK, check)
-PKG_CHECK_MODULES(LIBPCI, libpci)
+
+AC_ARG_ENABLE([bootloader],
+    AS_HELP_STRING([--disable-bootloader], [Compile the bootloader disabled, only make the tools]),
+	[enable_bootloader="no"],
+	[enable_bootloader="yes"])
+
+AS_IF([test "x$enable_bootloader" != "xno"], [
+    PKG_CHECK_MODULES(LIBPCI, libpci)
+])
+AM_CONDITIONAL([BOOTLOADER], [test "x$enable_bootloader" != "xno"])
 
 dnl Python
 AC_PATH_PROGS(PYTHON, [python3 python3.9 python3.8 python3.7 python3.6 python2.7 python2], no)
@@ -199,6 +208,8 @@ AC_MSG_RESULT([
 
 	arch:                    $ARCH
 	machine type:            $MACHINE_TYPE_NAME
+
+	build efi bootloader:    ${enable_bootloader}
 
 	prefix:                  ${prefix}
 	exec_prefix:             ${exec_prefix}


### PR DESCRIPTION
For native builds where only tools are needed, the libpci
detection and the bootloader build can be disabled.