### PR TITLE
Fix: Resolve Segmentation Fault when building with BusyBox/`ash`

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -234,7 +234,7 @@ fi
 # Note: gnu-efi introduced pkg-config with version 3.0.16
 # GNU_EFI_VERSION resolves to gnu-efi's version without dots, e.g., GNU_EFI_VERSION=3016
 # gnu-efi versions < 3.0.16 resolve to GNU_EFI_VERSION=0
-AC_SUBST([GNU_EFI_VERSION], [$(($PKG_CONFIG --modversion "gnu-efi" 2>/dev/null || echo 0) | $TR -d '.' )])
+AC_SUBST([GNU_EFI_VERSION], [$( ($PKG_CONFIG --modversion "gnu-efi" 2>/dev/null || echo 0) | $TR -d '.' )])
 AC_DEFINE_UNQUOTED([GNU_EFI_VERSION], [${GNU_EFI_VERSION}], [gnu-efi version])
 
 AC_SUBST([OBJCOPY_HAS_EFI_APP_TARGET], [$($OBJCOPY --info | $GREP -q pei- 2>/dev/null && echo "true")])


### PR DESCRIPTION
This pull request resolves a segmentation fault caused by the `configure` script, when building `efibootguard` using the BusyBox shell `ash`. The segmentation fault seems to be caused by the BusyBox shell consuming the opening `$((` as the beginning of an arithmetic statement:

```sh
busybox sh -c 'echo $((echo 0) | cat)'
# sh: syntax error: missing '))'
```

When running the changed line of code manually, the BusyBox shell throws a syntax error, as shown above, while it crashes due to a segmentation fault when the opening `$((` is located within the `configure` script. To mitigate this, this pull request simply inserts one space character between the opening double paranthesis, whereby the BusyBox shell no longer tries to parse this as an arithmetic expression.

<details><summary>Alpine Linux <code>abuild</code> logs without this patch</summary>

```
$ abuild -r
>>> efibootguard: Building testing/efibootguard 0.21-r0 (using abuild 3.15.0-r0) started Wed, 24 Sep 2025 11:00:43 +0200
>>> efibootguard: Validating /path/to/aports/testing/efibootguard/APKBUILD...
>>> efibootguard: Analyzing dependencies...
>>> efibootguard: Installing for build: build-base python3 argp-standalone autoconf autoconf-archive automake bsd-compat-headers check-dev gnu-efi-dev libtool linux-headers pciutils-dev py3-shtab
(1/1) Installing .makedepends-efibootguard (20250924.090046)
OK: 2717 MiB in 1021 packages
>>> efibootguard: Cleaning up srcdir
>>> efibootguard: Cleaning up pkgdir
>>> efibootguard: Cleaning up tmpdir
>>> efibootguard: Fetching efibootguard-0.21.tar.gz::https://github.com/siemens/efibootguard/archive/v0.21/efibootguard-0.21.tar.gz
>>> efibootguard: Fetching efibootguard-0.21.tar.gz::https://github.com/siemens/efibootguard/archive/v0.21/efibootguard-0.21.tar.gz
>>> efibootguard: Checking sha512sums...
efibootguard-0.21.tar.gz: OK
0001-fallback-outb_p.patch: OK
>>> efibootguard: Unpacking /var/cache/distfiles/efibootguard-0.21.tar.gz...
>>> efibootguard: 0001-fallback-outb_p.patch
patching file drivers/watchdog/w83627hf_wdt.c
autoreconf: export WARNINGS=
autoreconf: Entering directory '.'
autoreconf: configure.ac: not using Gettext
autoreconf: running: aclocal --force -I m4 --install ${ACLOCAL_FLAGS}
aclocal: installing 'm4/ax_check_compile_flag.m4' from '/usr/share/aclocal/ax_check_compile_flag.m4'
aclocal: installing 'm4/ax_check_link_flag.m4' from '/usr/share/aclocal/ax_check_link_flag.m4'
aclocal: installing 'm4/ax_valgrind_check.m4' from '/usr/share/aclocal/ax_valgrind_check.m4'
aclocal: installing 'm4/libtool.m4' from '/usr/share/aclocal/libtool.m4'
aclocal: installing 'm4/ltoptions.m4' from '/usr/share/aclocal/ltoptions.m4'
aclocal: installing 'm4/ltsugar.m4' from '/usr/share/aclocal/ltsugar.m4'
aclocal: installing 'm4/ltversion.m4' from '/usr/share/aclocal/ltversion.m4'
aclocal: installing 'm4/lt~obsolete.m4' from '/usr/share/aclocal/lt~obsolete.m4'
aclocal: installing 'm4/pkg.m4' from '/usr/share/aclocal/pkg.m4'
autoreconf: configure.ac: tracing
autoreconf: configure.ac: creating directory build-aux
autoreconf: running: libtoolize --copy --force
libtoolize: putting auxiliary files in AC_CONFIG_AUX_DIR, 'build-aux'.
libtoolize: copying file 'build-aux/ltmain.sh'
libtoolize: putting macros in AC_CONFIG_MACRO_DIRS, 'm4'.
libtoolize: copying file 'm4/libtool.m4'
libtoolize: copying file 'm4/ltoptions.m4'
libtoolize: copying file 'm4/ltsugar.m4'
libtoolize: copying file 'm4/ltversion.m4'
libtoolize: copying file 'm4/lt~obsolete.m4'
autoreconf: configure.ac: not using Intltool
autoreconf: configure.ac: not using Gtkdoc
autoreconf: running: aclocal --force -I m4 --install ${ACLOCAL_FLAGS}
autoreconf: running: /usr/bin/autoconf --force
configure.ac:49: warning: The macro 'AC_PROG_CC_C99' is obsolete.
configure.ac:49: You should run autoupdate.
./lib/autoconf/c.m4:1662: AC_PROG_CC_C99 is expanded from...
configure.ac:49: the top level
configure.ac:51: warning: The macro 'AC_PROG_GCC_TRADITIONAL' is obsolete.
configure.ac:51: You should run autoupdate.
./lib/autoconf/c.m4:1676: AC_PROG_GCC_TRADITIONAL is expanded from...
configure.ac:51: the top level
autoreconf: running: /usr/bin/autoheader --force
autoreconf: running: automake --add-missing --copy --force-missing
configure.ac:31: installing 'build-aux/compile'
configure.ac:31: installing 'build-aux/config.guess'
configure.ac:31: installing 'build-aux/config.sub'
configure.ac:33: installing 'build-aux/install-sh'
configure.ac:33: installing 'build-aux/missing'
Makefile.am: installing 'build-aux/depcomp'
parallel-tests: installing 'build-aux/test-driver'
autoreconf: Leaving directory '.'
checking build system type... x86_64-pc-linux-musl
checking host system type... x86_64-pc-linux-musl
checking how to print strings... printf
checking for gcc... cc
checking whether the C compiler works... yes
checking for C compiler default output file name... a.out
checking for suffix of executables... 
checking whether we are cross compiling... no
checking for suffix of object files... o
checking whether the compiler supports GNU C... yes
checking whether cc accepts -g... yes
checking for cc option to enable C11 features... none needed
checking whether cc understands -c and -o together... yes
checking for a sed that does not truncate output... /bin/sed
checking for grep that handles long lines and -e... /bin/grep
checking for egrep... /bin/grep -E
checking for fgrep... /bin/grep -F
checking for ld used by cc... /usr/x86_64-alpine-linux-musl/bin/ld
checking if the linker (/usr/x86_64-alpine-linux-musl/bin/ld) is GNU ld... yes
checking for BSD- or MS-compatible name lister (nm)... /usr/bin/nm -B
checking the name lister (/usr/bin/nm -B) interface... BSD nm
checking whether ln -s works... yes
checking the maximum length of command line arguments... 98304
checking how to convert x86_64-pc-linux-musl file names to x86_64-pc-linux-musl format... func_convert_file_noop
checking how to convert x86_64-pc-linux-musl file names to toolchain format... func_convert_file_noop
checking for /usr/x86_64-alpine-linux-musl/bin/ld option to reload object files... -r
checking for file... file
checking for objdump... objdump
checking how to recognize dependent libraries... pass_all
checking for dlltool... no
checking how to associate runtime and link libraries... printf %s\n
checking for ranlib... ranlib
checking for ar... ar
checking for archiver @FILE support... @
checking for strip... strip
checking for gawk... no
checking for mawk... no
checking for nawk... no
checking for awk... awk
checking command to parse /usr/bin/nm -B output from cc object... ok
checking for sysroot... no
checking for a working dd... /bin/dd
checking how to truncate binary pipes... /bin/dd bs=4096 count=1
checking for mt... no
checking if : is a manifest tool... no
checking for stdio.h... yes
checking for stdlib.h... yes
checking for string.h... yes
checking for inttypes.h... yes
checking for stdint.h... yes
checking for strings.h... yes
checking for sys/stat.h... yes
checking for sys/types.h... yes
checking for unistd.h... yes
checking for dlfcn.h... yes
checking for objdir... .libs
checking if cc supports -fno-rtti -fno-exceptions... no
checking for cc option to produce PIC... -fPIC -DPIC
checking if cc PIC flag -fPIC -DPIC works... yes
checking if cc static flag -static works... yes
checking if cc supports -c -o file.o... yes
checking if cc supports -c -o file.o... (cached) yes
checking whether the cc linker (/usr/x86_64-alpine-linux-musl/bin/ld -m elf_x86_64) supports shared libraries... yes
checking whether -lc should be explicitly linked in... no
checking dynamic linker characteristics... GNU/Linux ld.so
checking how to hardcode library paths into programs... immediate
checking whether stripping libraries is possible... yes
checking if libtool supports shared libraries... yes
checking whether to build shared libraries... yes
checking whether to build static libraries... yes
checking for a BSD-compatible install... /usr/bin/install -c
checking whether sleep supports fractional seconds... yes
checking filesystem timestamp resolution... 2
checking whether build environment is sane... yes
checking for a race-free mkdir -p... /bin/mkdir -p
checking whether make sets $(MAKE)... yes
checking whether make supports the include directive... yes (GNU style)
checking whether make supports nested variables... yes
checking xargs -n works... yes
checking how to create a pax tar archive... gnutar
checking dependency style of cc... gcc3
checking for cc option to enable large file support... none needed
checking for gcc... (cached) cc
checking whether the compiler supports GNU C... (cached) yes
checking whether cc accepts -g... (cached) yes
checking for cc option to enable C11 features... (cached) none needed
checking whether cc understands -c and -o together... (cached) yes
checking for ld... /usr/x86_64-alpine-linux-musl/bin/ld -m elf_x86_64
checking for objcopy... objcopy
checking for grep... /bin/grep
checking for tr... tr
checking whether ln -s works... yes
checking for egrep... (cached) /bin/grep -E
checking whether the C compiler accepts -mgeneral-regs-only... yes
checking for getmntent... yes
checking for memset... yes
checking for rmdir... yes
checking for strstr... yes
checking for strtol... yes
checking for fcntl.h... yes
checking for mntent.h... yes
checking for stddef.h... yes
checking for stdint.h... (cached) yes
checking for stdlib.h... (cached) yes
checking for string.h... (cached) yes
checking for sys/file.h... yes
checking for sys/mount.h... yes
checking for unistd.h... (cached) yes
checking for wchar.h... yes
checking for _Bool... yes
checking for stdbool.h that conforms to C99 or later... yes
checking for library containing getmntent... none required
checking whether the compiler supports GNU C++... yes
checking whether c++ accepts -g... yes
checking for c++ option to enable C++11 features... none needed
checking how to run the C++ preprocessor... c++ -E
checking for ld used by c++... /usr/x86_64-alpine-linux-musl/bin/ld -m elf_x86_64
checking if the linker (/usr/x86_64-alpine-linux-musl/bin/ld -m elf_x86_64) is GNU ld... yes
checking whether the c++ linker (/usr/x86_64-alpine-linux-musl/bin/ld -m elf_x86_64) supports shared libraries... yes
checking for c++ option to produce PIC... -fPIC -DPIC
checking if c++ PIC flag -fPIC -DPIC works... yes
checking if c++ static flag -static works... yes
checking if c++ supports -c -o file.o... yes
checking if c++ supports -c -o file.o... (cached) yes
checking whether the c++ linker (/usr/x86_64-alpine-linux-musl/bin/ld -m elf_x86_64) supports shared libraries... yes
checking dynamic linker characteristics... (cached) GNU/Linux ld.so
checking how to hardcode library paths into programs... immediate
checking dependency style of c++... gcc3
checking for int32_t... yes
checking for off_t... yes
checking for size_t... yes
checking for uint16_t... yes
checking for uint32_t... yes
checking for uint8_t... yes
checking for pkg-config... /usr/bin/pkg-config
checking pkg-config is at least version 0.9.0... yes
Segmentation fault
>>> ERROR: efibootguard: build failed
>>> efibootguard: Uninstalling dependencies...
```

</details>

<details><summary>Alpine Linux <code>abuild</code> logs with this patch applied</summary>

```
$ abuild -r
>>> efibootguard: Building testing/efibootguard 0.21-r0 (using abuild 3.15.0-r0) started Wed, 24 Sep 2025 11:06:22 +0200
>>> efibootguard: Validating /path/to/aports/testing/efibootguard/APKBUILD...
>>> efibootguard: Analyzing dependencies...
>>> efibootguard: Installing for build: build-base python3 argp-standalone autoconf autoconf-archive automake bsd-compat-headers check-dev gnu-efi-dev libtool linux-headers pciutils-dev py3-shtab
(1/1) Installing .makedepends-efibootguard (20250924.090625)
OK: 2717 MiB in 1021 packages
>>> efibootguard: Cleaning up srcdir
>>> efibootguard: Cleaning up pkgdir
>>> efibootguard: Cleaning up tmpdir
>>> efibootguard: Fetching efibootguard-0.21.tar.gz::https://github.com/siemens/efibootguard/archive/v0.21/efibootguard-0.21.tar.gz
>>> efibootguard: Fetching efibootguard-0.21.tar.gz::https://github.com/siemens/efibootguard/archive/v0.21/efibootguard-0.21.tar.gz
>>> efibootguard: Checking sha512sums...
efibootguard-0.21.tar.gz: OK
0001-fallback-outb_p.patch: OK
0002-configure.patch: OK
>>> efibootguard: Unpacking /var/cache/distfiles/efibootguard-0.21.tar.gz...
>>> efibootguard: 0001-fallback-outb_p.patch
patching file drivers/watchdog/w83627hf_wdt.c
>>> efibootguard: 0002-configure.patch
patching file configure.ac
autoreconf: export WARNINGS=
autoreconf: Entering directory '.'
autoreconf: configure.ac: not using Gettext
autoreconf: running: aclocal --force -I m4 --install ${ACLOCAL_FLAGS}
aclocal: installing 'm4/ax_check_compile_flag.m4' from '/usr/share/aclocal/ax_check_compile_flag.m4'
aclocal: installing 'm4/ax_check_link_flag.m4' from '/usr/share/aclocal/ax_check_link_flag.m4'
aclocal: installing 'm4/ax_valgrind_check.m4' from '/usr/share/aclocal/ax_valgrind_check.m4'
aclocal: installing 'm4/libtool.m4' from '/usr/share/aclocal/libtool.m4'
aclocal: installing 'm4/ltoptions.m4' from '/usr/share/aclocal/ltoptions.m4'
aclocal: installing 'm4/ltsugar.m4' from '/usr/share/aclocal/ltsugar.m4'
aclocal: installing 'm4/ltversion.m4' from '/usr/share/aclocal/ltversion.m4'
aclocal: installing 'm4/lt~obsolete.m4' from '/usr/share/aclocal/lt~obsolete.m4'
aclocal: installing 'm4/pkg.m4' from '/usr/share/aclocal/pkg.m4'
autoreconf: configure.ac: tracing
autoreconf: configure.ac: creating directory build-aux
autoreconf: running: libtoolize --copy --force
libtoolize: putting auxiliary files in AC_CONFIG_AUX_DIR, 'build-aux'.
libtoolize: copying file 'build-aux/ltmain.sh'
libtoolize: putting macros in AC_CONFIG_MACRO_DIRS, 'm4'.
libtoolize: copying file 'm4/libtool.m4'
libtoolize: copying file 'm4/ltoptions.m4'
libtoolize: copying file 'm4/ltsugar.m4'
libtoolize: copying file 'm4/ltversion.m4'
libtoolize: copying file 'm4/lt~obsolete.m4'
autoreconf: configure.ac: not using Intltool
autoreconf: configure.ac: not using Gtkdoc
autoreconf: running: aclocal --force -I m4 --install ${ACLOCAL_FLAGS}
autoreconf: running: /usr/bin/autoconf --force
configure.ac:49: warning: The macro 'AC_PROG_CC_C99' is obsolete.
configure.ac:49: You should run autoupdate.
./lib/autoconf/c.m4:1662: AC_PROG_CC_C99 is expanded from...
configure.ac:49: the top level
configure.ac:51: warning: The macro 'AC_PROG_GCC_TRADITIONAL' is obsolete.
configure.ac:51: You should run autoupdate.
./lib/autoconf/c.m4:1676: AC_PROG_GCC_TRADITIONAL is expanded from...
configure.ac:51: the top level
autoreconf: running: /usr/bin/autoheader --force
autoreconf: running: automake --add-missing --copy --force-missing
configure.ac:31: installing 'build-aux/compile'
configure.ac:31: installing 'build-aux/config.guess'
configure.ac:31: installing 'build-aux/config.sub'
configure.ac:33: installing 'build-aux/install-sh'
configure.ac:33: installing 'build-aux/missing'
Makefile.am: installing 'build-aux/depcomp'
parallel-tests: installing 'build-aux/test-driver'
autoreconf: Leaving directory '.'
checking build system type... x86_64-pc-linux-musl
checking host system type... x86_64-pc-linux-musl
checking how to print strings... printf
checking for gcc... cc
checking whether the C compiler works... yes
checking for C compiler default output file name... a.out
checking for suffix of executables... 
checking whether we are cross compiling... no
checking for suffix of object files... o
checking whether the compiler supports GNU C... yes
checking whether cc accepts -g... yes
checking for cc option to enable C11 features... none needed
checking whether cc understands -c and -o together... yes
checking for a sed that does not truncate output... /bin/sed
checking for grep that handles long lines and -e... /bin/grep
checking for egrep... /bin/grep -E
checking for fgrep... /bin/grep -F
checking for ld used by cc... /usr/x86_64-alpine-linux-musl/bin/ld
checking if the linker (/usr/x86_64-alpine-linux-musl/bin/ld) is GNU ld... yes
checking for BSD- or MS-compatible name lister (nm)... /usr/bin/nm -B
checking the name lister (/usr/bin/nm -B) interface... BSD nm
checking whether ln -s works... yes
checking the maximum length of command line arguments... 98304
checking how to convert x86_64-pc-linux-musl file names to x86_64-pc-linux-musl format... func_convert_file_noop
checking how to convert x86_64-pc-linux-musl file names to toolchain format... func_convert_file_noop
checking for /usr/x86_64-alpine-linux-musl/bin/ld option to reload object files... -r
checking for file... file
checking for objdump... objdump
checking how to recognize dependent libraries... pass_all
checking for dlltool... no
checking how to associate runtime and link libraries... printf %s\n
checking for ranlib... ranlib
checking for ar... ar
checking for archiver @FILE support... @
checking for strip... strip
checking for gawk... no
checking for mawk... no
checking for nawk... no
checking for awk... awk
checking command to parse /usr/bin/nm -B output from cc object... ok
checking for sysroot... no
checking for a working dd... /bin/dd
checking how to truncate binary pipes... /bin/dd bs=4096 count=1
checking for mt... no
checking if : is a manifest tool... no
checking for stdio.h... yes
checking for stdlib.h... yes
checking for string.h... yes
checking for inttypes.h... yes
checking for stdint.h... yes
checking for strings.h... yes
checking for sys/stat.h... yes
checking for sys/types.h... yes
checking for unistd.h... yes
checking for dlfcn.h... yes
checking for objdir... .libs
checking if cc supports -fno-rtti -fno-exceptions... no
checking for cc option to produce PIC... -fPIC -DPIC
checking if cc PIC flag -fPIC -DPIC works... yes
checking if cc static flag -static works... yes
checking if cc supports -c -o file.o... yes
checking if cc supports -c -o file.o... (cached) yes
checking whether the cc linker (/usr/x86_64-alpine-linux-musl/bin/ld -m elf_x86_64) supports shared libraries... yes
checking whether -lc should be explicitly linked in... no
checking dynamic linker characteristics... GNU/Linux ld.so
checking how to hardcode library paths into programs... immediate
checking whether stripping libraries is possible... yes
checking if libtool supports shared libraries... yes
checking whether to build shared libraries... yes
checking whether to build static libraries... yes
checking for a BSD-compatible install... /usr/bin/install -c
checking whether sleep supports fractional seconds... yes
checking filesystem timestamp resolution... 2
checking whether build environment is sane... yes
checking for a race-free mkdir -p... /bin/mkdir -p
checking whether make sets $(MAKE)... yes
checking whether make supports the include directive... yes (GNU style)
checking whether make supports nested variables... yes
checking xargs -n works... yes
checking how to create a pax tar archive... gnutar
checking dependency style of cc... gcc3
checking for cc option to enable large file support... none needed
checking for gcc... (cached) cc
checking whether the compiler supports GNU C... (cached) yes
checking whether cc accepts -g... (cached) yes
checking for cc option to enable C11 features... (cached) none needed
checking whether cc understands -c and -o together... (cached) yes
checking for ld... /usr/x86_64-alpine-linux-musl/bin/ld -m elf_x86_64
checking for objcopy... objcopy
checking for grep... /bin/grep
checking for tr... tr
checking whether ln -s works... yes
checking for egrep... (cached) /bin/grep -E
checking whether the C compiler accepts -mgeneral-regs-only... yes
checking for getmntent... yes
checking for memset... yes
checking for rmdir... yes
checking for strstr... yes
checking for strtol... yes
checking for fcntl.h... yes
checking for mntent.h... yes
checking for stddef.h... yes
checking for stdint.h... (cached) yes
checking for stdlib.h... (cached) yes
checking for string.h... (cached) yes
checking for sys/file.h... yes
checking for sys/mount.h... yes
checking for unistd.h... (cached) yes
checking for wchar.h... yes
checking for _Bool... yes
checking for stdbool.h that conforms to C99 or later... yes
checking for library containing getmntent... none required
checking whether the compiler supports GNU C++... yes
checking whether c++ accepts -g... yes
checking for c++ option to enable C++11 features... none needed
checking how to run the C++ preprocessor... c++ -E
checking for ld used by c++... /usr/x86_64-alpine-linux-musl/bin/ld -m elf_x86_64
checking if the linker (/usr/x86_64-alpine-linux-musl/bin/ld -m elf_x86_64) is GNU ld... yes
checking whether the c++ linker (/usr/x86_64-alpine-linux-musl/bin/ld -m elf_x86_64) supports shared libraries... yes
checking for c++ option to produce PIC... -fPIC -DPIC
checking if c++ PIC flag -fPIC -DPIC works... yes
checking if c++ static flag -static works... yes
checking if c++ supports -c -o file.o... yes
checking if c++ supports -c -o file.o... (cached) yes
checking whether the c++ linker (/usr/x86_64-alpine-linux-musl/bin/ld -m elf_x86_64) supports shared libraries... yes
checking dynamic linker characteristics... (cached) GNU/Linux ld.so
checking how to hardcode library paths into programs... immediate
checking dependency style of c++... gcc3
checking for int32_t... yes
checking for off_t... yes
checking for size_t... yes
checking for uint16_t... yes
checking for uint32_t... yes
checking for uint8_t... yes
checking for pkg-config... /usr/bin/pkg-config
checking pkg-config is at least version 0.9.0... yes
checking for libpci... yes
checking for check... yes
checking for python3... /usr/bin/python3
checking for valgrind... no
checking that generated files are newer than configure... done
configure: creating ./config.status
config.status: creating Makefile
config.status: creating libebgenv.pc
config.status: creating tools/tests/Makefile
config.status: creating config.h
config.status: executing libtool commands
config.status: executing depfiles commands

	efibootguard v0.21

	arch:                    x86_64
	machine type:            x64

	build efi bootloader:    yes
	enable shell completion: yes

	prefix:                  /usr
	exec_prefix:             ${prefix}
	libexecdir:              ${exec_prefix}/libexec
	libdir:                  ${exec_prefix}/lib

	efi libs:                /usr/lib

	environment backend:     env_api_fat.c
	environment file name:   BGENV.DAT
	number of config parts:  2
	reserved for uservars:   131072 bytes
	silent boot:             no
	boot delay:              0 seconds

make --no-print-directory all-recursive
Making all in .
  CHK      version.h
  GEN      completion/bash/bg_setenv.bash
  GEN      completion/bash/bg_printenv.bash
  UPD      version.h
  CC       drivers/watchdog/wdfuncs_start.o
  CC       drivers/watchdog/wdat.o
  CC       drivers/watchdog/amdfch_wdt.o
  CC       drivers/watchdog/i6300esb.o
  CC       drivers/watchdog/atom-quark.o
  CC       drivers/watchdog/ipcbx21a.o
  CC       drivers/watchdog/ipc4x7e_wdt.o
  CC       drivers/watchdog/w83627hf_wdt.o
  CC       drivers/watchdog/ipmi_wdt.o
  CC       drivers/watchdog/itco.o
  CC       drivers/watchdog/hpwdt.o
  CC       drivers/watchdog/eiois200_wdt.o
  CC       drivers/utils/simatic.o
  CC       drivers/utils/smbios.o
  CC       drivers/watchdog/wdfuncs_end.o
  CC       env/syspart.o
  CC       env/fatvars.o
  CC       kernel-stub/fdt.o
  CC       kernel-stub/initrd.o
  CC       kernel-stub/main.o
  GEN      completion/zsh/_bg_setenv
  GEN      completion/zsh/_bg_printenv
  CC       tools/bg_setenv-bg_setenv.o
  CC       tools/bg_setenv-bg_printenv.o
  CC       tools/bg_setenv-bg_envtools.o
  CC       tools/bg_setenv-main.o
  CC       env/libebgenv_a-env_api_fat.o
  CC       env/libebgenv_a-env_api.o
  CC       env/libebgenv_a-env_api_crc32.o
  CC       env/libebgenv_a-env_config_file.o
  CC       env/libebgenv_a-env_config_partitions.o
  CC       env/libebgenv_a-env_disk_utils.o
  CC       env/libebgenv_a-uservars.o
  CC       tools/libebgenv_a-ebgpart.o
  CC       tools/libebgenv_a-fat.o
  CC       env/env_api_fat.lo
  CC       env/env_api.lo
  CC       env/env_api_crc32.lo
  CC       env/env_config_file.lo
  CC       env/env_config_partitions.lo
  CC       env/env_disk_utils.lo
  CC       env/uservars.lo
  CC       tools/ebgpart.lo
  CC       tools/fat.lo
  CC       utils.o
  CC       loader_interface.o
  CC       bootguard.o
  CC       main.o
  CCLD     kernel-stub/kernel-stubx64.so
  AR       libebgenv.a
  CCLD     bg_setenv
  GEN      kernel-stubx64.efi
  CCLD     efibootguardx64.so
  GEN      efibootguardx64.efi
  CCLD     libebgenv.la
Making all in tools/tests
make[2]: Nothing to be done for 'all'.
>>> efibootguard: Entering fakeroot...
Making install in .
  CHK      version.h
  CHK      version.h
 /bin/mkdir -p '/path/to/aports/testing/efibootguard/pkg/efibootguard/usr/bin'
 /bin/mkdir -p '/path/to/aports/testing/efibootguard/pkg/efibootguard/usr/share/efibootguard/completion/bash'
 /usr/bin/install -c tools/bg_gen_unified_kernel '/path/to/aports/testing/efibootguard/pkg/efibootguard/usr/bin'
 /usr/bin/install -c -m 644 ./completion/bash/bg_setenv.bash ./completion/bash/bg_printenv.bash '/path/to/aports/testing/efibootguard/pkg/efibootguard/usr/share/efibootguard/completion/bash'
 /bin/mkdir -p '/path/to/aports/testing/efibootguard/pkg/efibootguard/usr/lib/pkgconfig'
 /bin/mkdir -p '/path/to/aports/testing/efibootguard/pkg/efibootguard/usr/include/efibootguard'
 /bin/mkdir -p '/path/to/aports/testing/efibootguard/pkg/efibootguard/usr/share/efibootguard/completion/zsh'
 /bin/mkdir -p '/path/to/aports/testing/efibootguard/pkg/efibootguard/usr/lib'
 /usr/bin/install -c -m 644 libebgenv.pc '/path/to/aports/testing/efibootguard/pkg/efibootguard/usr/lib/pkgconfig'
 /usr/bin/install -c -m 644 ./completion/zsh/_bg_setenv ./completion/zsh/_bg_printenv '/path/to/aports/testing/efibootguard/pkg/efibootguard/usr/share/efibootguard/completion/zsh'
 /bin/sh ./libtool   --mode=install /usr/bin/install -c   libebgenv.la '/path/to/aports/testing/efibootguard/pkg/efibootguard/usr/lib'
 /usr/bin/install -c -m 644 include/ebgenv.h '/path/to/aports/testing/efibootguard/pkg/efibootguard/usr/include/efibootguard'
 /bin/mkdir -p '/path/to/aports/testing/efibootguard/pkg/efibootguard/usr/lib'
 /bin/mkdir -p '/path/to/aports/testing/efibootguard/pkg/efibootguard/usr/lib/efibootguard'
 /usr/bin/install -c -m 644  libebgenv.a '/path/to/aports/testing/efibootguard/pkg/efibootguard/usr/lib'
 /usr/bin/install -c -m 644 efibootguardx64.efi kernel-stubx64.efi '/path/to/aports/testing/efibootguard/pkg/efibootguard/usr/lib/efibootguard'
 ( cd '/path/to/aports/testing/efibootguard/pkg/efibootguard/usr/lib' && ranlib libebgenv.a )
libtool: install: /usr/bin/install -c .libs/libebgenv.so.0.1.0 /path/to/aports/testing/efibootguard/pkg/efibootguard/usr/lib/libebgenv.so.0.1.0
libtool: install: (cd /path/to/aports/testing/efibootguard/pkg/efibootguard/usr/lib && { ln -s -f libebgenv.so.0.1.0 libebgenv.so.0 || { rm -f libebgenv.so.0 && ln -s libebgenv.so.0.1.0 libebgenv.so.0; }; })
libtool: install: (cd /path/to/aports/testing/efibootguard/pkg/efibootguard/usr/lib && { ln -s -f libebgenv.so.0.1.0 libebgenv.so || { rm -f libebgenv.so && ln -s libebgenv.so.0.1.0 libebgenv.so; }; })
libtool: install: /usr/bin/install -c .libs/libebgenv.lai /path/to/aports/testing/efibootguard/pkg/efibootguard/usr/lib/libebgenv.la
libtool: install: /usr/bin/install -c .libs/libebgenv.a /path/to/aports/testing/efibootguard/pkg/efibootguard/usr/lib/libebgenv.a
libtool: install: chmod 644 /path/to/aports/testing/efibootguard/pkg/efibootguard/usr/lib/libebgenv.a
libtool: install: ranlib /path/to/aports/testing/efibootguard/pkg/efibootguard/usr/lib/libebgenv.a
libtool: warning: remember to run 'libtool --finish /usr/lib'
 /bin/mkdir -p '/path/to/aports/testing/efibootguard/pkg/efibootguard/usr/bin'
  /bin/sh ./libtool   --mode=install /usr/bin/install -c bg_setenv '/path/to/aports/testing/efibootguard/pkg/efibootguard/usr/bin'
libtool: install: /usr/bin/install -c bg_setenv /path/to/aports/testing/efibootguard/pkg/efibootguard/usr/bin/bg_setenv
make --no-print-directory install-exec-hook
rm -f /path/to/aports/testing/efibootguard/pkg/efibootguard/usr/lib/libebgenv.la
Making install in tools/tests
make[2]: Nothing to be done for 'install-exec-am'.
make[2]: Nothing to be done for 'install-data-am'.
>>> efibootguard-dev*: Running split function dev...
'usr/include' -> '/path/to/aports/testing/efibootguard/pkg/efibootguard-dev/usr/include'
'usr/lib/pkgconfig' -> '/path/to/aports/testing/efibootguard/pkg/efibootguard-dev/usr/lib/pkgconfig'
'usr/lib/libebgenv.a' -> '/path/to/aports/testing/efibootguard/pkg/efibootguard-dev/usr/lib/libebgenv.a'
'usr/lib/libebgenv.so' -> '/path/to/aports/testing/efibootguard/pkg/efibootguard-dev/usr/lib/libebgenv.so'
>>> efibootguard-dev*: Preparing subpackage efibootguard-dev...
>>> efibootguard-dev*: Stripping binaries
>>> efibootguard-dev*: Running postcheck for efibootguard-dev
>>> efibootguard-bash-completion*: Running split function bashcomp...
'usr/share/bash-completion/completions' -> '/path/to/aports/testing/efibootguard/pkg/efibootguard-bash-completion/usr/share/bash-completion/completions'
>>> efibootguard-bash-completion*: Preparing subpackage efibootguard-bash-completion...
>>> efibootguard-bash-completion*: Running postcheck for efibootguard-bash-completion
>>> efibootguard-zsh-completion*: Running split function zshcomp...
'usr/share/zsh/site-functions' -> '/path/to/aports/testing/efibootguard/pkg/efibootguard-zsh-completion/usr/share/zsh/site-functions'
>>> efibootguard-zsh-completion*: Preparing subpackage efibootguard-zsh-completion...
>>> efibootguard-zsh-completion*: Running postcheck for efibootguard-zsh-completion
>>> efibootguard*: Running postcheck for efibootguard
>>> efibootguard*: Preparing package efibootguard...
>>> efibootguard*: Stripping binaries
>>> efibootguard-bash-completion*: Scanning shared objects
>>> efibootguard-dev*: Scanning shared objects
>>> efibootguard-zsh-completion*: Scanning shared objects
>>> efibootguard*: Scanning shared objects
>>> efibootguard-bash-completion*: Tracing dependencies...
>>> efibootguard-bash-completion*: Package size: 10.2 KB
>>> efibootguard-bash-completion*: Compressing data...
>>> efibootguard-bash-completion*: Create checksum...
>>> efibootguard-bash-completion*: Create efibootguard-bash-completion-0.21-r0.apk
>>> efibootguard-dev*: Tracing dependencies...
	efibootguard=0.21-r0
	pkgconfig
>>> efibootguard-dev*: Package size: 67.1 KB
>>> efibootguard-dev*: Compressing data...
>>> efibootguard-dev*: Create checksum...
>>> efibootguard-dev*: Create efibootguard-dev-0.21-r0.apk
>>> efibootguard-zsh-completion*: Tracing dependencies...
>>> efibootguard-zsh-completion*: Package size: 3.6 KB
>>> efibootguard-zsh-completion*: Compressing data...
>>> efibootguard-zsh-completion*: Create checksum...
>>> efibootguard-zsh-completion*: Create efibootguard-zsh-completion-0.21-r0.apk
>>> efibootguard*: Tracing dependencies...
	python3
	so:libc.musl-x86_64.so.1
>>> efibootguard*: Package size: 253.9 KB
>>> efibootguard*: Compressing data...
>>> efibootguard*: Create checksum...
>>> efibootguard*: Create efibootguard-0.21-r0.apk
>>> efibootguard: Build complete at Wed, 24 Sep 2025 11:06:49 +0200 elapsed time 0h 0m 27s
```

</details>